### PR TITLE
Fix PIQT radio button visibility

### DIFF
--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -77,9 +77,10 @@
                             </fieldset>
                         </td>
                         <td>
-                            <fieldset style="width:300px;height:80px">
+                            <fieldset style="width:320px">
                                 <legend>Axis</legend>
                                 <table>
+                                    <tr>
                                     <td>
                                         <input type="radio" id="type_RATE_R" name="Axis" onchange="loading_call(setup_axis)">
                                         <label for="type_RATE_R">RATE Roll</label><br>
@@ -106,6 +107,7 @@
                                         <input type="radio" id="type_PIQT" name="Axis" onchange="loading_call(setup_axis)">
                                         <label for="type_PIQT">PIQT</label><br>
                                     </td>
+                                    </tr>
                                 </table>
                             </fieldset>
                         </td>


### PR DESCRIPTION
## Summary
- ensure the PIQT radio button is selectable by removing the fixed height and adding a row wrapper

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e5d81e3b48320a12870e6ca0664db